### PR TITLE
Bump various gem versions for security patch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ GEM
     factory_bot (4.8.2)
       activesupport (>= 3.0.0)
     i18n (0.8.6)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (0.9.0)
@@ -49,7 +49,7 @@ GEM
       railties
     mini_portile2 (2.3.0)
     minitest (5.10.3)
-    nokogiri (1.8.2)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     pg (0.21.0)
     rack (2.0.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,7 +52,7 @@ GEM
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     pg (0.21.0)
-    rack (2.0.3)
+    rack (2.0.6)
     rack-test (0.7.0)
       rack (>= 1.0, < 3)
     rails-dom-testing (2.0.3)


### PR DESCRIPTION
loofah:
https://nvd.nist.gov/vuln/detail/CVE-2018-16468

rack:
https://nvd.nist.gov/vuln/detail/CVE-2018-16470
https://nvd.nist.gov/vuln/detail/CVE-2018-16471